### PR TITLE
fix(caasmapper): map FILE entries

### DIFF
--- a/src/modules/CaaSMapper.ts
+++ b/src/modules/CaaSMapper.ts
@@ -9,6 +9,7 @@ import {
   CaaSApi_GCAPage,
   CaaSApi_Media,
   CaaSApi_Media_Picture,
+  CaaSApi_Media_File,
   CaaSApi_PageRef,
   CaaSApi_Section,
   CaaSApi_SectionReference,
@@ -18,6 +19,7 @@ import {
   Dataset,
   GCAPage,
   Image,
+  File,
   Media,
   NestedPath,
   Page,
@@ -289,10 +291,23 @@ export class CaaSMapper {
     }
   }
 
-  async mapMedia(item: CaaSApi_Media, path: NestedPath): Promise<Image | any | null> {
+  async mapMediaFile(item: CaaSApi_Media_File, path: NestedPath): Promise<File> {
+    return {
+      id: item.identifier,
+      previewId: this.buildPreviewId(item.identifier),
+      meta: await this.mapDataEntries(item.metaFormData, [...path, 'meta']),
+      fileName: item.fileName,
+      fileMetaData: item.fileMetaData,
+      url: item.url
+    }
+  }
+
+  async mapMedia(item: CaaSApi_Media, path: NestedPath): Promise<Image | File | null> {
     switch (item.mediaType) {
       case 'PICTURE':
         return this.mapMediaPicture(item, path)
+      case 'FILE':
+        return this.mapMediaFile(item, path)
       default:
         return item
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -453,6 +453,20 @@ export interface Image {
   }
 }
 
+export interface File {
+  id: string
+  previewId: string
+  meta: DataEntries
+  fileName: string
+  url: string
+  fileMetaData: {
+    fileSize: number
+    extension: string
+    mimeType: string
+    encoding: string | null
+  }
+}
+
 export interface RegisteredDatasetQuery {
   name: string
   filterParams: Record<string, string>


### PR DESCRIPTION
Media entries of type FILE are explicitly mapped

remark: The change from d85f2e71f6 is not sufficient, since in resolveReferences the item is looked up by "id", which doesn't exist on CaaS items.
return {...item, id: item.identifier}
instead of
return item
would presumably work as well and could maybe added additionally as a fallback?