### PR TITLE
fix(xml-parser): map div tag to block type

### DIFF
--- a/src/modules/XMLParser.ts
+++ b/src/modules/XMLParser.ts
@@ -125,11 +125,16 @@ class XMLParser {
           type: 'linebreak'
         }
       case 'p':
-      case 'div':
         return {
           data: tag.attributes,
           content: [],
           type: 'paragraph'
+        }
+      case 'div':
+        return {
+          data: tag.attributes,
+          content: [],
+          type: 'block'
         }
       case 'link':
         const data = tag.attributes

--- a/src/types.ts
+++ b/src/types.ts
@@ -592,7 +592,7 @@ export interface MappedFilter {
 }
 
 export interface RichTextElement {
-  type: 'text' | 'paragraph' | 'list' | 'listitem' | 'linebreak' | 'link' | string
+  type: 'block' | 'text' | 'paragraph' | 'list' | 'listitem' | 'linebreak' | 'link' | string
   content: RichTextElement[] | string
   data: Record<string, any>
 }


### PR DESCRIPTION
This PR relates to #8 and fixes the incorrect mapping for the div tag