### PR TITLE
fix: 🐛 fixed additionalParams for fetchByFilter

### DIFF
--- a/src/modules/FSXAApi.ts
+++ b/src/modules/FSXAApi.ts
@@ -249,8 +249,10 @@ export class FSXAApi {
     Object.keys(additionalParams).forEach(key => {
       if (Array.isArray(additionalParams[key])) {
         buildAdditionalParams[key] = additionalParams[key].map(JSON.stringify)
-      } else {
+      } else if (typeof additionalParams[key] === 'object') {
         buildAdditionalParams[key] = JSON.stringify(additionalParams[key])
+      } else {
+        buildAdditionalParams[key] = additionalParams[key]
       }
     })
     // we need to encode array

--- a/src/modules/FSXAApi.ts
+++ b/src/modules/FSXAApi.ts
@@ -250,7 +250,7 @@ export class FSXAApi {
       if (Array.isArray(additionalParams[key])) {
         buildAdditionalParams[key] = additionalParams[key].map(JSON.stringify)
       } else {
-        buildAdditionalParams[key] = additionalParams[key]
+        buildAdditionalParams[key] = JSON.stringify(additionalParams[key])
       }
     })
     // we need to encode array


### PR DESCRIPTION
We have fixed the issue that the user had to stringify the keys if only
an object was passed. Now the FSXA-Api does that directly.