### PR TITLE
fix(express.ts): fix the body request locale error message

### DIFF
--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -16,7 +16,7 @@ export interface GetExpressRouterContext {
   api: FSXAApi
 }
 export enum ExpressRouterIntegrationErrors {
-  MISSING_LOCALE = 'Please specify a locale through locale.',
+  MISSING_LOCALE = 'Please specify a locale in the body through: e.g. "locale": "de_DE" ',
   UNKNOWN_ROUTE = 'Could not map given route and method.'
 }
 function getExpressRouter({ api }: GetExpressRouterContext) {

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -16,7 +16,7 @@ export interface GetExpressRouterContext {
   api: FSXAApi
 }
 export enum ExpressRouterIntegrationErrors {
-  MISSING_LOCALE = 'Please specify a locale through ?locale.',
+  MISSING_LOCALE = 'Please specify a locale through locale.',
   UNKNOWN_ROUTE = 'Could not map given route and method.'
 }
 function getExpressRouter({ api }: GetExpressRouterContext) {


### PR DESCRIPTION
In the express.ts file is an error message for the missing locale. This message is misleading and
changed, because a request otherwise throw an bad request error.
