### PR TITLE
fix(express.ts): fix the deprecated method

### DIFF
--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -21,7 +21,7 @@ export enum ExpressRouterIntegrationErrors {
 }
 function getExpressRouter({ api }: GetExpressRouterContext) {
   const router = express.Router()
-  router.use(bodyParser.json())
+  router.use(express.json())
   router.post(
     FETCH_ELEMENT_ROUTE,
     async (req: express.Request<FetchElementRouteParams, any, FetchElementRouteBody>, res) => {

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -16,7 +16,7 @@ export interface GetExpressRouterContext {
   api: FSXAApi
 }
 export enum ExpressRouterIntegrationErrors {
-  MISSING_LOCALE = 'Please specify a locale through locale.',
+  MISSING_LOCALE = 'Please specify a locale in the body through: e.g. "locale": "de_DE" ',
   UNKNOWN_ROUTE = 'Could not map given route and method.'
 }
 function getExpressRouter({ api }: GetExpressRouterContext) {

--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -16,7 +16,7 @@ export interface GetExpressRouterContext {
   api: FSXAApi
 }
 export enum ExpressRouterIntegrationErrors {
-  MISSING_LOCALE = 'Please specify a locale through ?locale.',
+  MISSING_LOCALE = 'Please specify a locale through locale.',
   UNKNOWN_ROUTE = 'Could not map given route and method.'
 }
 function getExpressRouter({ api }: GetExpressRouterContext) {


### PR DESCRIPTION
Change the express router method and replace "bodyparser.json" to "express.json", because the bodyparser method was outdated for express 4 or higher.