### PR TITLE
fix(express.ts): fix the deprecated express method

### DIFF
--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -21,7 +21,7 @@ export enum ExpressRouterIntegrationErrors {
 }
 function getExpressRouter({ api }: GetExpressRouterContext) {
   const router = express.Router()
-  router.use(bodyParser.json())
+  router.use(express.json())
   router.post(
     FETCH_ELEMENT_ROUTE,
     async (req: express.Request<FetchElementRouteParams, any, FetchElementRouteBody>, res) => {


### PR DESCRIPTION
Change the express router method and replace "bodyparser.json" to "express.json" because the
bodyparser method was deprecated.