### PR TITLE
feat(caasmapper): added type names to interfaces used by mapper

### DIFF
--- a/src/modules/CaaSMapper.ts
+++ b/src/modules/CaaSMapper.ts
@@ -26,7 +26,10 @@ import {
   PageBody,
   PageBodyContent,
   ProjectProperties,
-  Section
+  Section,
+  Link,
+  Option,
+  CaaSApi_FSIndex
 } from '../types'
 import { parseISO } from 'date-fns'
 import { set, chunk } from 'lodash'
@@ -126,7 +129,9 @@ export class CaaSMapper {
     }
     switch (entry.fsType) {
       case 'CMS_INPUT_COMBOBOX':
-        return entry.value ? { key: entry.value.identifier, value: entry.value.label } : null
+        return entry.value
+          ? ({ type: 'Option', key: entry.value.identifier, value: entry.value.label } as Option)
+          : null
       case 'CMS_INPUT_DOM':
       case 'CMS_INPUT_DOMTABLE':
         return entry.value ? await this.xmlParser.parse(entry.value) : []
@@ -140,11 +145,12 @@ export class CaaSMapper {
         return entry.value ? parseISO(entry.value) : null
       case 'CMS_INPUT_LINK':
         return entry.value
-          ? {
+          ? ({
+              type: 'Link',
               template: entry.value.template.uid,
               data: await this.mapDataEntries(entry.value.formData, [...path, 'data']),
               meta: await this.mapDataEntries(entry.value.metaFormData, [...path, 'meta'])
-            }
+            } as Link)
           : null
       case 'CMS_INPUT_LIST':
         if (!entry.value) return []
@@ -216,12 +222,13 @@ export class CaaSMapper {
             return this.registerReferencedItem(record.value.target.identifier, [...path, index])
           })
         }
-        return entry
+        return entry as CaaSApi_FSIndex
       case 'Option':
         return {
+          type: 'Option',
           key: entry.identifier,
           value: entry.label
-        }
+        } as Option
       default:
         this.api.logger.log(
           `[mapDataEntry]: Unknown Type ${entry.fsType}. Returning raw value:`,
@@ -308,6 +315,7 @@ export class CaaSMapper {
 
   async mapPageRef(pageRef: CaaSApi_PageRef, path: NestedPath = []): Promise<Page> {
     return {
+      type: 'Page',
       id: pageRef.page.identifier,
       refId: pageRef.identifier,
       previewId: this.buildPreviewId(pageRef.identifier),
@@ -328,6 +336,7 @@ export class CaaSMapper {
     path: NestedPath = []
   ): Promise<ProjectProperties> {
     return {
+      type: 'ProjectProperties',
       data: await this.mapDataEntries(properties.formData, [...path, 'data']),
       layout: properties.template.uid,
       meta: await this.mapDataEntries(properties.metaFormData, [...path, 'meta']),
@@ -339,6 +348,7 @@ export class CaaSMapper {
 
   async mapGCAPage(gcaPage: CaaSApi_GCAPage, path: NestedPath = []): Promise<GCAPage> {
     return {
+      type: 'GCAPage',
       id: gcaPage.identifier,
       previewId: this.buildPreviewId(gcaPage.identifier),
       name: gcaPage.name,
@@ -364,6 +374,7 @@ export class CaaSMapper {
 
   async mapMediaPicture(item: CaaSApi_Media_Picture, path: NestedPath): Promise<Image> {
     return {
+      type: 'Image',
       id: item.identifier,
       previewId: this.buildPreviewId(item.identifier),
       meta: await this.mapDataEntries(item.metaFormData, [...path, 'meta']),
@@ -374,6 +385,7 @@ export class CaaSMapper {
 
   async mapMediaFile(item: CaaSApi_Media_File, path: NestedPath): Promise<File> {
     return {
+      type: 'File',
       id: item.identifier,
       previewId: this.buildPreviewId(item.identifier),
       meta: await this.mapDataEntries(item.metaFormData, [...path, 'meta']),

--- a/src/types.ts
+++ b/src/types.ts
@@ -379,6 +379,7 @@ export interface PageBody {
 }
 
 export interface Page {
+  type?: 'Page'
   id: string
   refId: string
   previewId: string
@@ -390,11 +391,13 @@ export interface Page {
 }
 
 export interface Option {
+  type?: 'Option'
   key: string
   value: string
 }
 
 export interface Link {
+  type?: 'Link'
   template: string
   data: DataEntries
   meta: DataEntries
@@ -410,6 +413,7 @@ export interface Card {
 export interface Media {}
 
 export interface GCAPage {
+  type?: 'GCAPage'
   id: string
   previewId: string
   name: string
@@ -419,6 +423,7 @@ export interface GCAPage {
 }
 
 export interface ProjectProperties {
+  type?: 'ProjectProperties'
   id: string
   previewId: string
   name: string
@@ -446,19 +451,19 @@ export interface Content2Section {
 }
 
 export interface Section {
+  type: 'Section'
   id: string
   previewId: string
-  type: 'Section'
   sectionType: string
   data: DataEntries
   children: Section[]
 }
 
 export interface Dataset {
+  type: 'Dataset'
   id: string
   previewId: string
   schema: string
-  type: 'Dataset'
   entityType: string
   template: string
   children: Section[]
@@ -467,6 +472,7 @@ export interface Dataset {
 }
 
 export interface Image {
+  type?: 'Image'
   id: string
   previewId: string
   meta: DataEntries
@@ -484,6 +490,7 @@ export interface Image {
 }
 
 export interface File {
+  type?: 'File'
   id: string
   previewId: string
   meta: DataEntries


### PR DESCRIPTION
Added (optional) type names to interfaces used by CaaSMapper.
Since Types are not existent at runtime, those typenames enable easy differentiation of interfaces at runtime