### PR TITLE
feat(caasmapper): add customizable media url builder, to add revision in preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,33 @@
-## [6.0.1](https://github.com/e-Spirit/fsxa-api/compare/v6.0.0...v6.0.1) (2021-12-21)
+### UPDATE NOTICE
 
+If you are using a CustomMapper to handle CaaS requests, you need to implement following method signature in the mapper's utils object:
+
+```typescript
+buildMediaUrl: (url: string, rev?: number) => string
+```
+
+This method can be used to change returning URLs of CaaSApi_Media_Picture.
+
+## [6.0.1](https://github.com/e-Spirit/fsxa-api/compare/v6.0.0...v6.0.1) (2021-12-21)
 
 ### Bug Fixes
 
-* **types:** add FSXAProxyApiConfig type for explicit definition of proxy api config ([#62](https://github.com/e-Spirit/fsxa-api/issues/62)) ([1d4144c](https://github.com/e-Spirit/fsxa-api/commit/1d4144c0ad744727e05616b5b7929ff25afa1253))
+- **types:** add FSXAProxyApiConfig type for explicit definition of proxy api config ([#62](https://github.com/e-Spirit/fsxa-api/issues/62)) ([1d4144c](https://github.com/e-Spirit/fsxa-api/commit/1d4144c0ad744727e05616b5b7929ff25afa1253))
 
 # [6.0.0](https://github.com/e-Spirit/fsxa-api/compare/v5.4.2...v6.0.0) (2021-12-07)
 
-
 ### Bug Fixes
 
-* fix version number ([#60](https://github.com/e-Spirit/fsxa-api/issues/60)) ([5e8b3d0](https://github.com/e-Spirit/fsxa-api/commit/5e8b3d0d0212a43e204ca1dd81778aeb185f7c3c))
-
+- fix version number ([#60](https://github.com/e-Spirit/fsxa-api/issues/60)) ([5e8b3d0](https://github.com/e-Spirit/fsxa-api/commit/5e8b3d0d0212a43e204ca1dd81778aeb185f7c3c))
 
 ### Features
 
-* add FSXAProxy, FSXARemoteApi and navigationFilter utilities ([#58](https://github.com/e-Spirit/fsxa-api/issues/58)) ([e909dc0](https://github.com/e-Spirit/fsxa-api/commit/e909dc0e9e49a45ec5da966fabf460fa0a3d9fb2)), closes [#44](https://github.com/e-Spirit/fsxa-api/issues/44) [#55](https://github.com/e-Spirit/fsxa-api/issues/55) [#57](https://github.com/e-Spirit/fsxa-api/issues/57) [#47](https://github.com/e-Spirit/fsxa-api/issues/47) [#49](https://github.com/e-Spirit/fsxa-api/issues/49)
-
+- add FSXAProxy, FSXARemoteApi and navigationFilter utilities ([#58](https://github.com/e-Spirit/fsxa-api/issues/58)) ([e909dc0](https://github.com/e-Spirit/fsxa-api/commit/e909dc0e9e49a45ec5da966fabf460fa0a3d9fb2)), closes [#44](https://github.com/e-Spirit/fsxa-api/issues/44) [#55](https://github.com/e-Spirit/fsxa-api/issues/55) [#57](https://github.com/e-Spirit/fsxa-api/issues/57) [#47](https://github.com/e-Spirit/fsxa-api/issues/47) [#49](https://github.com/e-Spirit/fsxa-api/issues/49)
 
 ### BREAKING CHANGES
 
-* The FSXAApi class was removed and new classes FSXAProxyApi and FSXARemoteApi was
-added. Please read the [migration guide in the CHANGELOG](https://github.com/e-Spirit/fsxa-api/blob/alpha/CHANGELOG.md#migration-guide) for more details.
+- The FSXAApi class was removed and new classes FSXAProxyApi and FSXARemoteApi was
+  added. Please read the [migration guide in the CHANGELOG](https://github.com/e-Spirit/fsxa-api/blob/alpha/CHANGELOG.md#migration-guide) for more details.
 
 ### Migration Guide
 
@@ -37,7 +43,7 @@ To be compliant to the new signature, you can wrap the parameters of your method
 _Example_:
 
 ```typescript
-api.fetchElement(req.body.id, req.body.locale, req.body?.additionalParams, req.body?.remote);
+api.fetchElement(req.body.id, req.body.locale, req.body?.additionalParams, req.body?.remote)
 ```
 
 _does not compile_
@@ -48,7 +54,7 @@ api.fetchElement({
   locale: req.body.locale,
   additionalParams: req.body?.additionalParams,
   remoteProject: req.body?.remote,
-});
+})
 ```
 
 _new compliant solution_
@@ -64,17 +70,17 @@ _Example_:
 new FSXAApi(
   FSXAContentMode.PREVIEW,
   {
-    mode: "proxy",
+    mode: 'proxy',
     baseUrl: BASE_URL,
   },
   3
-);
+)
 ```
 
 _does not compile_
 
 ```typescript
-new FSXAProxyApi(BASE_URL, LogLevel.INFO);
+new FSXAProxyApi(BASE_URL, LogLevel.INFO)
 ```
 
 _new compliant solution_
@@ -82,13 +88,13 @@ _new compliant solution_
 #### Usages of FSXAApi with mode = remote
 
 FSXAApi has been removed.
-If you were using the FSXAApi in with `mode: 'remote'` you should switch to the new FSXARemoteApi.
+If you were using the FSXAApi with `mode: 'remote'` you should switch to the new FSXARemoteApi.
 
 _Example_:
 
 ```typescript
 new FSXAApi(FSXAContentMode.PREVIEW, {
-  mode: "remote",
+  mode: 'remote',
   config: {
     apiKey: API_KEY,
     caas: CAAS_URL,
@@ -97,7 +103,7 @@ new FSXAApi(FSXAContentMode.PREVIEW, {
     projectId: PROJECT_ID,
     remotes: REMOTES,
   },
-});
+})
 ```
 
 _does not compile_
@@ -111,7 +117,7 @@ new FSXARemoteApi({
   projectID: PROJECT_ID,
   remotes: REMOTES,
   contentMode: CONTENT_MODE,
-});
+})
 ```
 
 _new compliant solution_

--- a/src/modules/CaaSMapper.ts
+++ b/src/modules/CaaSMapper.ts
@@ -8,6 +8,7 @@ import {
   CaaSApi_GCAPage,
   CaaSApi_Media,
   CaaSApi_Media_Picture,
+  CaaSApiMediaPictureResolutions as CaaSApiMediaPictureResolutions,
   CaaSApi_Media_File,
   CaaSApi_PageRef,
   CaaSApi_ProjectProperties,
@@ -33,6 +34,7 @@ import { set, chunk } from 'lodash'
 import XMLParser from './XMLParser'
 import { Logger } from './Logger'
 import { FSXARemoteApi } from './FSXARemoteApi'
+import { FSXAContentMode } from '..'
 
 export enum CaaSMapperErrors {
   UNKNOWN_BODY_CONTENT = 'Unknown BodyContent could not be mapped.',
@@ -114,6 +116,13 @@ export class CaaSMapper {
     return [identifier, this.locale].join('.')
   }
 
+  buildMediaUrl(url: string, rev?: number) {
+    if (rev && this.api.contentMode === FSXAContentMode.PREVIEW) {
+      url += `${url.includes('?') ? '&' : '?'}rev=${rev}`
+    }
+    return url
+  }
+
   async mapDataEntry(entry: CaaSApi_DataEntry, path: NestedPath): Promise<DataEntry> {
     if (this.customMapper) {
       const result = await this.customMapper(entry, path, {
@@ -121,6 +130,7 @@ export class CaaSMapper {
         xmlParser: this.xmlParser,
         registerReferencedItem: this.registerReferencedItem.bind(this),
         buildPreviewId: this.buildPreviewId.bind(this),
+        buildMediaUrl: this.buildMediaUrl.bind(this),
         mapDataEntries: this.mapDataEntries.bind(this),
       })
       if (typeof result !== 'undefined') return result
@@ -368,8 +378,21 @@ export class CaaSMapper {
       previewId: this.buildPreviewId(item.identifier),
       meta: await this.mapDataEntries(item.metaFormData, [...path, 'meta']),
       description: item.description,
-      resolutions: item.resolutionsMetaData,
+      resolutions: this.mapMediaPictureResolutionUrls(
+        item.resolutionsMetaData,
+        item.changeInfo?.revision
+      ),
     }
+  }
+
+  mapMediaPictureResolutionUrls(
+    resolutions: CaaSApiMediaPictureResolutions,
+    rev?: number
+  ): CaaSApiMediaPictureResolutions {
+    for (let resolution in resolutions) {
+      resolutions[resolution].url = this.buildMediaUrl(resolutions[resolution].url, rev)
+    }
+    return resolutions
   }
 
   async mapMediaFile(item: CaaSApi_Media_File, path: NestedPath): Promise<File> {

--- a/src/modules/CaaSMapper.ts
+++ b/src/modules/CaaSMapper.ts
@@ -8,7 +8,7 @@ import {
   CaaSApi_GCAPage,
   CaaSApi_Media,
   CaaSApi_Media_Picture,
-  CaaSApiMediaPictureResolutions as CaaSApiMediaPictureResolutions,
+  CaaSApiMediaPictureResolutions,
   CaaSApi_Media_File,
   CaaSApi_PageRef,
   CaaSApi_ProjectProperties,

--- a/src/types.ts
+++ b/src/types.ts
@@ -327,6 +327,7 @@ export interface CaaSApi_Media_Base {
   languageDependent: boolean
   description: string | null
   metaFormData: CaaSApi_DataEntries
+  changeInfo?: { revision: number }
 }
 
 export interface CaaSApi_Media_File extends CaaSApi_Media_Base {
@@ -340,18 +341,21 @@ export interface CaaSApi_Media_File extends CaaSApi_Media_Base {
   }
 }
 
+export type CaaSApi_Media_Picture_Resolution_MetaData = {
+  fileSize: number
+  extension: string
+  mimeType: string
+  width: number
+  height: number
+  url: string
+}
+
+export interface CaaSApiMediaPictureResolutions {
+  [resolution: string]: CaaSApi_Media_Picture_Resolution_MetaData
+}
 export interface CaaSApi_Media_Picture extends CaaSApi_Media_Base {
   mediaType: 'PICTURE'
-  resolutionsMetaData: {
-    [resolution: string]: {
-      fileSize: number
-      extension: string
-      mimeType: string
-      width: number
-      height: number
-      url: string
-    }
-  }
+  resolutionsMetaData: CaaSApiMediaPictureResolutions
 }
 
 export type CaaSApi_Media = CaaSApi_Media_File | CaaSApi_Media_Picture
@@ -519,6 +523,7 @@ export type CustomMapper = (
     xmlParser: XMLParser
     registerReferencedItem: (identifier: string, path: NestedPath) => string
     buildPreviewId: (identifier: string) => string
+    buildMediaUrl: (url: string, rev?: number) => string
     mapDataEntries: (entries: CaaSApi_DataEntries, path: NestedPath) => Promise<DataEntries>
   }
 ) => Promise<any>


### PR DESCRIPTION
Added new default behavior that adds the revision of a medium to its url. Also added the
possibility to overwrite this behavior with a CustomMapper. Please read the update notice for
further details.