### PR TITLE
feat: update response structure of fetchByFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
-# [6.1.0](https://github.com/e-Spirit/fsxa-api/compare/v6.0.1...v6.1.0) (2021-12-23)
+### BREAKING CHANGE
 
+Previously fetchByFilter directly returned an array of returned items. Now this
+data is wrapped in an "items" property.
+
+Example:
+```typescript
+const { items } = fetchByFilter({...}) as { items: any[] }
+```
+
+The returned object also includes pagination data ("page" and "pagesize") now.
+If you are using "additionalParams" you can extend the pagination data with "totalPages" and "size" by passing `count: true`. Using "count" has performance implication for it involves querying the collection twice: once for counting and once of actually retrieving the data;
+
+# [6.1.0](https://github.com/e-Spirit/fsxa-api/compare/v6.0.1...v6.1.0) (2021-12-23)
 
 ### Features
 
-* **caasmapper:** add customizable media url builder, to add revision in preview mode ([#63](https://github.com/e-Spirit/fsxa-api/issues/63)) ([88e6c45](https://github.com/e-Spirit/fsxa-api/commit/88e6c45492a2e7e9774c19a72742e8a3bc48a806))
+- **caasmapper:** add customizable media url builder, to add revision in preview mode ([#63](https://github.com/e-Spirit/fsxa-api/issues/63)) ([88e6c45](https://github.com/e-Spirit/fsxa-api/commit/88e6c45492a2e7e9774c19a72742e8a3bc48a806))
 
 ### UPDATE NOTICE
 

--- a/src/integrations/express.spec.ts
+++ b/src/integrations/express.spec.ts
@@ -38,7 +38,13 @@ describe('Express-Integration', () => {
     fetchNavigationSpy = jest
       .spyOn(remoteApi, 'fetchNavigation')
       .mockImplementation(async () => ({ foo: 'bar' } as any as NavigationData))
-    fetchByFilterSpy = jest.spyOn(remoteApi, 'fetchByFilter').mockImplementation(async () => [])
+    fetchByFilterSpy = jest.spyOn(remoteApi, 'fetchByFilter').mockImplementation(async () => ({
+      page: 1,
+      pagesize: 30,
+      pages: 0,
+      total: 0,
+      items: [],
+    }))
   })
 
   afterEach(() => {
@@ -170,7 +176,9 @@ describe('Express-Integration', () => {
       await proxyApi.fetchByFilter({ filters: [], locale: 'de_DE' })
       expect(fetchByFilterSpy).toHaveBeenCalledTimes(1)
       expect(fetchByFilterSpy).toHaveBeenCalledWith({
-        additionalParams: {},
+        additionalParams: {
+          rep: 'hal',
+        },
         filters: [],
         locale: 'de_DE',
         page: 1,
@@ -213,7 +221,7 @@ describe('Express-Integration', () => {
       expect(fetchByFilterSpy.mock.calls[3][0].page).toEqual(3)
       expect(fetchByFilterSpy.mock.calls[3][0].pagesize).toEqual(30)
 
-      const additionalParams = { keys: ['1', '2', '3'], sort: '-age' }
+      const additionalParams = { keys: ['1', '2', '3'], sort: '-age', rep: 'hal' }
       await proxyApi.fetchByFilter({
         filters: [],
         locale: 'de_DE',

--- a/src/modules/FSXAProxyApi.spec.ts
+++ b/src/modules/FSXAProxyApi.spec.ts
@@ -140,7 +140,10 @@ describe('FSXAProxyAPI', () => {
       expect(actualBody.locale).toEqual(locale)
       expect(actualBody.page).toEqual(page)
       expect(actualBody.pagesize).toEqual(pagesize)
-      expect(actualBody.additionalParams).toStrictEqual(additionalParams)
+      expect(actualBody.additionalParams).toStrictEqual({
+        ...additionalParams,
+        rep: 'hal',
+      })
       expect(actualBody.remote).toEqual(remoteProject)
       expect(actualReferrer).toEqual('')
     })
@@ -198,14 +201,23 @@ describe('FSXAProxyAPI', () => {
     })
 
     it('should return the response', async () => {
-      const expectedResponse = Faker.datatype.array()
+      const items = Faker.datatype.array()
+
+      const expectedResponse = {
+        page: 1,
+        pagesize: 30,
+        pages: 0,
+        total: 0,
+        items,
+      }
+
       fetchMock.mockResponseOnce(JSON.stringify(expectedResponse))
 
       const actualResponse = await proxyApi.fetchByFilter({
         filters: defaultFilters,
         locale,
       })
-      expect(expectedResponse).toEqual(actualResponse)
+      expect(actualResponse).toEqual(expectedResponse)
     })
   })
   describe('fetchNavigation', () => {

--- a/src/modules/FSXAProxyApi.ts
+++ b/src/modules/FSXAProxyApi.ts
@@ -12,6 +12,7 @@ import {
 } from '../types'
 import { FSXAApiErrors, FSXAProxyRoutes } from '../enums'
 import { Logger, LogLevel } from './Logger'
+import { FetchResponse } from '..'
 
 interface RequestOptions extends Omit<RequestInit, 'body'> {
   body?: BodyInit | null | object
@@ -127,7 +128,7 @@ export class FSXAProxyApi implements FSXAApi {
     additionalParams = {},
     remoteProject,
     fetchOptions,
-  }: FetchByFilterParams) {
+  }: FetchByFilterParams): Promise<FetchResponse> {
     if (pagesize < 1) {
       this._logger.warn(
         'fetchByFilter',
@@ -157,7 +158,10 @@ export class FSXAProxyApi implements FSXAApi {
       locale,
       page,
       pagesize,
-      additionalParams,
+      additionalParams: {
+        ...additionalParams,
+        rep: 'hal',
+      },
       remote: remoteProject,
     }
     this._logger.debug('fetchByFilter', 'trying to fetch with body', body)

--- a/src/modules/FSXARemoteApi.spec.ts
+++ b/src/modules/FSXARemoteApi.spec.ts
@@ -117,7 +117,7 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const actualCaaSUrl = remoteApi.buildCaaSUrl()
-      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?`
+      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
     it('should return the correct caas url for a remote project', () => {
@@ -125,7 +125,7 @@ describe('FSXARemoteAPI', () => {
       const remoteApi = new FSXARemoteApi(config)
       const remoteProjectId = config.remotes.remote.id
       const actualCaaSUrl = remoteApi.buildCaaSUrl({ remoteProject: 'remote' })
-      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${remoteProjectId}.${config.contentMode}.content?`
+      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${remoteProjectId}.${config.contentMode}.content`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
     it('should return the correct caas url with a locale but no id', () => {
@@ -133,7 +133,7 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const actualCaaSUrl = remoteApi.buildCaaSUrl({ locale })
-      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?`
+      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
     it('should return the correct caas url when an id is set', () => {
@@ -141,7 +141,7 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const actualCaaSUrl = remoteApi.buildCaaSUrl({ id })
-      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content/${id}?`
+      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content/${id}`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
     it('should return the correct caas url when additionalParameter are set', () => {
@@ -149,7 +149,7 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const actualCaaSUrl = remoteApi.buildCaaSUrl({ additionalParams })
-      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?&keys={"firstValue":1}&keys={"secondValue":1}`
+      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?keys={"firstValue":1,"secondValue":1}`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
     it('should return the correct caas url when id, locale and additionalParameter are set', () => {
@@ -159,7 +159,7 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const actualCaaSUrl = remoteApi.buildCaaSUrl({ id, locale, additionalParams })
-      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content/${id}.${locale}?&keys={"firstValue":1}&keys={"secondValue":1}&sort={"firstName":1}`
+      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content/${id}.${locale}?keys={"firstValue":1,"secondValue":1}&sort={"firstName":1}`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
     it('should return the correct caas url when filters are set', () => {
@@ -184,9 +184,9 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const actualCaaSUrl = remoteApi.buildCaaSUrl({ filters })
-      const firstFilter = `&filter={"${firstField}":{"${firstOperator}":"${firstValue}"}}`
-      const secondFilter = `&filter={"${secondField}":{"${secondOperator}":"${secondValue}"}}`
-      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?${firstFilter}${secondFilter}`
+      const firstFilter = `filter={"${firstField}":{"${firstOperator}":"${firstValue}"}}`
+      const secondFilter = `filter={"${secondField}":{"${secondOperator}":"${secondValue}"}}`
+      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?${firstFilter}&${secondFilter}`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
     it('should return the correct caas url when filters and additionalParams are set', () => {
@@ -208,9 +208,9 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const actualCaaSUrl = remoteApi.buildCaaSUrl({ filters, additionalParams })
-      const additionalParamsQuery = `&keys={"identifier":1}`
-      const filterQuery = `&filter={"${filterField}":{"${filterOperator}":"${filterValue}"}}`
-      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?${additionalParamsQuery}${filterQuery}`
+      const additionalParamsQuery = `keys={"identifier":1}`
+      const filterQuery = `filter={"${filterField}":{"${filterOperator}":"${filterValue}"}}`
+      const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?${additionalParamsQuery}&${filterQuery}`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
     it('should return the correct caas url when page is set', () => {
@@ -218,7 +218,7 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const actualCaaSUrl = remoteApi.buildCaaSUrl({ page })
-      const pageQuery = `&page=${page}`
+      const pageQuery = `page=${page}`
       const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?${pageQuery}`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
@@ -227,7 +227,7 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const actualCaaSUrl = remoteApi.buildCaaSUrl({ pagesize })
-      const pagesizeQuery = `&pagesize=${pagesize}`
+      const pagesizeQuery = `pagesize=${pagesize}`
       const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?${pagesizeQuery}`
       expect(expectedCaaSUrl).toStrictEqual(actualCaaSUrl)
     })
@@ -290,7 +290,7 @@ describe('FSXARemoteAPI', () => {
       fetchMock.mockResponseOnce(Faker.datatype.json())
       remoteApi.fetchElement({ id: uuid, locale })
       const actualURL = fetchMock.mock.calls[0][0]
-      const expectedURL = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content/${uuid}.${locale}?`
+      const expectedURL = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content/${uuid}.${locale}`
       expect(expectedURL).toBe(actualURL)
     })
     it('should throw an not found error when the response is 404', () => {
@@ -362,7 +362,7 @@ describe('FSXARemoteAPI', () => {
       fetchMock.mockResponseOnce(JSON.stringify(json))
       remoteApi.fetchByFilter({ filters, locale })
       const actualURL = fetchMock.mock.calls[0][0]
-      const expectedURL = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?&filter={"${filterField}":{"$eq":"${filterValue}"}}&filter={"locale.language":{"$eq":"${localeLanguage}"}}&filter={"locale.country":{"$eq":"${localeCountry}"}}&page=1&pagesize=30`
+      const expectedURL = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?rep=hal&filter={"${filterField}":{"$eq":"${filterValue}"}}&filter={"locale.language":{"$eq":"${localeLanguage}"}}&filter={"locale.country":{"$eq":"${localeCountry}"}}&page=1&pagesize=30`
       expect(expectedURL).toBe(actualURL)
     })
     it('should throw an unauthorized error when the response is 401', () => {
@@ -379,7 +379,13 @@ describe('FSXARemoteAPI', () => {
       fetchMock.mockResponseOnce(JSON.stringify(json))
       const actualRequest = await remoteApi.fetchByFilter({ filters, locale })
       expect(actualRequest).toBeDefined()
-      expect(actualRequest).toStrictEqual(json._embedded['rh:doc'])
+      expect(actualRequest).toStrictEqual({
+        page: 1,
+        pagesize: 30,
+        size: undefined,
+        totalPages: undefined,
+        items: json._embedded['rh:doc'],
+      })
     })
   })
   describe('fetchNavigation', () => {
@@ -457,7 +463,7 @@ describe('FSXARemoteAPI', () => {
       remoteApi.fetchProjectProperties({ locale })
       const actualURL = fetchMock.mock.calls[0][0]
 
-      const expectedURL = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?&filter={"fsType":{"$eq":"ProjectProperties"}}&filter={"locale.language":{"$eq":"${localeLanguage}"}}&filter={"locale.country":{"$eq":"${localeCountry}"}}&page=1&pagesize=30`
+      const expectedURL = `${config.caasURL}/${config.tenantID}/${config.projectID}.${config.contentMode}.content?rep=hal&filter={"fsType":{"$eq":"ProjectProperties"}}&filter={"locale.language":{"$eq":"${localeLanguage}"}}&filter={"locale.country":{"$eq":"${localeCountry}"}}&page=1&pagesize=30`
       expect(expectedURL).toBe(actualURL)
     })
   })

--- a/src/modules/XMLParser.ts
+++ b/src/modules/XMLParser.ts
@@ -8,7 +8,7 @@ import { get } from 'lodash'
 const ENTITIES = new Map([
   ['"', '&quot;'],
   ['&', '&amp;'],
-  ['<', '&lt;']
+  ['<', '&lt;'],
 ])
 
 class XMLParser {

--- a/src/types.ts
+++ b/src/types.ts
@@ -712,9 +712,17 @@ export interface FSXAApi {
   fetchElement: <T = Page | GCAPage | Dataset | Image | any | null>(
     params: FetchElementParams
   ) => Promise<T>
-  fetchByFilter: (params: FetchByFilterParams) => Promise<any>
+  fetchByFilter: (params: FetchByFilterParams) => Promise<FetchResponse>
   fetchNavigation: (params: FetchNavigationParams) => Promise<NavigationData | null>
   fetchProjectProperties: (
     params: FetchProjectPropertiesParams
   ) => Promise<Record<string, any> | null>
+}
+
+export interface FetchResponse {
+  page: number
+  pagesize: number
+  totalPages?: number
+  size?: number
+  items: unknown[]
 }


### PR DESCRIPTION
fetchByFilter got an extended response structure

BREAKING CHANGE: Previously fetchByFilter directly returned an array of returned items. Now this
data is wrapped in an 'items' property. The returned object also includes pagination data now.