### PR TITLE
feat(runtime types): add type attributes to interfaces and CaasMapper

### DIFF
--- a/src/modules/CaaSMapper.ts
+++ b/src/modules/CaaSMapper.ts
@@ -31,7 +31,6 @@ import {
   ImageMapAreaCircle,
   ImageMapAreaPoly,
   ImageMapAreaRect,
-  Media,
   NestedPath,
   Page,
   PageBody,
@@ -44,7 +43,15 @@ import { chunk, set } from 'lodash'
 import XMLParser from './XMLParser'
 import { Logger } from './Logger'
 import { FSXARemoteApi } from './FSXARemoteApi'
-import { FSXAContentMode, Link, Option, Reference, RichTextElement, ImageMapAreaType } from '..'
+import {
+  FSXAContentMode,
+  Link,
+  Option,
+  Reference,
+  RichTextElement,
+  ImageMapAreaType,
+  ImageMapResolution,
+} from '..'
 
 export enum CaaSMapperErrors {
   UNKNOWN_BODY_CONTENT = 'Unknown BodyContent could not be mapped.',
@@ -422,6 +429,7 @@ export class CaaSMapper {
     const {
       value: { media, areas, resolution },
     } = imageMap
+
     this.logger.debug('CaaSMapper.mapImageMap - imageMap', imageMap)
     const [mappedAreas, mappedMedia] = await Promise.all([
       Promise.all(
@@ -430,10 +438,17 @@ export class CaaSMapper {
       this.mapMedia(media, path),
     ])
 
+    const imageMapResolution: ImageMapResolution = {
+      width: resolution.width,
+      height: resolution.height,
+      uid: resolution.uid,
+    }
+
     return {
+      type: 'ImageMap',
       areas: mappedAreas.filter(Boolean) as ImageMapArea[],
-      resolution,
-      media: mappedMedia as Image,
+      resolution: imageMapResolution,
+      media: mappedMedia?.type === 'Image' ? mappedMedia : null,
     }
   }
 

--- a/src/testutils/createImageMap.ts
+++ b/src/testutils/createImageMap.ts
@@ -54,7 +54,7 @@ export function createImageMap(): CaaSApi_CMSImageMap {
         } as CaaSApi_ImageMapAreaPoly,
       ],
       resolution: {
-        fsType: 'ImageMapResolution',
+        fsType: 'Resolution',
         uid: faker.datatype.uuid(),
         width: 1920,
         height: 1080,

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,7 @@ export interface CaaSApi_CMSImageMap {
     media: CaaSApi_Media
     areas: CaaSApi_ImageMapArea[]
     resolution: {
-      fsType: 'ImageMapResolution'
+      fsType: 'Resolution'
       uid: string
       width: number
       height: number
@@ -507,15 +507,17 @@ export interface ImageMapAreaPoly extends ImageMapArea {
   points: Point2D[]
 }
 
+export interface ImageMapResolution {
+  uid: string
+  width: number
+  height: number
+}
+
 export interface ImageMap {
-  media: Image
+  type: 'ImageMap'
+  media: Image | null
   areas: ImageMapArea[]
-  resolution: {
-    fsType: 'ImageMapResolution'
-    uid: string
-    width: number
-    height: number
-  }
+  resolution: ImageMapResolution
 }
 
 export interface Media {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,16 +196,6 @@ export interface CaaSApi_FSCatalog {
   value: CaaSApi_Card[] | null
 }
 
-export interface CaaSApi_MediaRef {
-  fsType: 'Media'
-  name: string
-  identifier: string
-  uid: string
-  uidType: string
-  mediaType: string
-  url: string
-}
-
 export interface CaaSApi_Record {
   fsType: 'Record'
   identifier: string
@@ -219,19 +209,37 @@ export interface CaaSApi_FSIndex {
   value: CaaSApi_Record[]
 }
 
+export interface CaaSApi_BaseRef {
+  fsType: string
+  name: string
+  identifier: string
+  uid: string
+  uidType: string
+  url: string
+  remoteProject?: string
+}
+
+export interface CaaSApi_MediaRef extends CaaSApi_BaseRef {
+  fsType: 'Media'
+  uidType: 'MEDIASTORE_LEAF'
+  mediaType: 'PICTURE' | 'FILE'
+}
+
+export interface CaaSApi_GCARef extends CaaSApi_BaseRef {
+  fsType: 'GCAPage'
+  uidType: 'GLOBALSTORE'
+  url: ''
+}
+
+export interface CaaSApi_PageRefRef extends CaaSApi_BaseRef {
+  fsType: 'PageRef'
+  uidType: 'SITESTORE_LEAF'
+}
+
 export interface CaaSApi_FSReference {
   fsType: 'FS_REFERENCE'
   name: string
-  value: {
-    fsType: 'Media'
-    name: string
-    identifier: string
-    uid: string
-    uidType: string
-    mediaType: 'PICTURE'
-    url: string
-    remoteProject: string
-  } | null
+  value: CaaSApi_BaseRef | CaaSApi_PageRefRef | CaaSApi_GCARef | CaaSApi_MediaRef | null
 }
 
 export type CaaSApi_DataEntry =

--- a/src/types.ts
+++ b/src/types.ts
@@ -378,12 +378,14 @@ export interface DataEntries {
 export type PageBodyContent = Section | Content2Section | Dataset
 
 export interface PageBody {
+  type: 'PageBody'
   name: string
   previewId: string
   children: PageBodyContent[]
 }
 
 export interface Page {
+  type: 'Page'
   id: string
   refId: string
   previewId: string
@@ -394,18 +396,27 @@ export interface Page {
   meta: DataEntries
 }
 
+export interface Reference {
+  type: 'Reference'
+  referenceId: string
+  referenceType: string
+}
+
 export interface Option {
+  type: 'Option'
   key: string
   value: string
 }
 
 export interface Link {
+  type: 'Link'
   template: string
   data: DataEntries
   meta: DataEntries
 }
 
 export interface Card {
+  type: 'Card'
   id: string
   previewId: string
   template: string
@@ -415,6 +426,7 @@ export interface Card {
 export interface Media {}
 
 export interface GCAPage {
+  type: 'GCAPage'
   id: string
   previewId: string
   name: string
@@ -424,6 +436,7 @@ export interface GCAPage {
 }
 
 export interface ProjectProperties {
+  type: 'ProjectProperties'
   id: string
   previewId: string
   name: string
@@ -451,19 +464,19 @@ export interface Content2Section {
 }
 
 export interface Section {
+  type: 'Section'
   id: string
   previewId: string
-  type: 'Section'
   sectionType: string
   data: DataEntries
   children: Section[]
 }
 
 export interface Dataset {
+  type: 'Dataset'
   id: string
   previewId: string
   schema: string
-  type: 'Dataset'
   entityType: string
   template: string
   children: Section[]
@@ -472,6 +485,7 @@ export interface Dataset {
 }
 
 export interface Image {
+  type: 'Image'
   id: string
   previewId: string
   meta: DataEntries
@@ -489,6 +503,7 @@ export interface Image {
 }
 
 export interface File {
+  type: 'File'
   id: string
   previewId: string
   meta: DataEntries


### PR DESCRIPTION
To check for types at runtime, explicit type information must be carried within the object.

BREAKING CHANGE: Added type attribute needs to be added if objects of changed interfaces are created
in user code