### PR TITLE
feat(caas-mapper): mapped links in doms (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Links inside of RichtTextElements will now be mapped in the same way as the value of CMS_INPUT_LINK.
+
+Make sure your implementation is compliant with the new signature of `Link | Record<string, any>`.
+Please refer the fsxa-api [type-mapping](https://github.com/e-Spirit/fsxa-api#type-mapping).
+
 ## [9.0.2](https://github.com/e-Spirit/fsxa-api/compare/v9.0.1...v9.0.2) (2022-05-06)
 
 

--- a/dev/utils.ts
+++ b/dev/utils.ts
@@ -1,9 +1,9 @@
 import fs from 'fs'
 
-export const createFolder = (dirName: string) => {
+export const createFolder = (dirName: string, recursive?: boolean) => {
   if (!fs.existsSync(dirName)) {
     console.info(`Folder ${dirName} was not found`)
-    fs.mkdirSync(dirName)
+    fs.mkdirSync(dirName, { recursive })
     console.info(`Folder ${dirName} was created`)
   }
 }
@@ -17,7 +17,7 @@ export const createFile = ({
   fileName: string
   content: unknown
 }) => {
-  createFolder(dirName)
+  createFolder(dirName, true)
   fs.writeFileSync(dirName + '/' + fileName, `{"result": ${JSON.stringify(content, null, 2)}}`)
   console.info(`Content was written to ${dirName}/${fileName}`)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -797,7 +797,7 @@ export interface MappedFilter {
 export interface RichTextElement {
   type: 'block' | 'text' | 'paragraph' | 'list' | 'listitem' | 'linebreak' | 'link' | string
   content: RichTextElement[] | string
-  data: Record<string, any>
+  data: Link | Record<string, any>
 }
 
 export type FetchNavigationParams = {


### PR DESCRIPTION
* feat(caas-mapper): map (nested) `Link`s in `RichTextElement`s

Links inside of RichtTextElements will now be mapped in the same way as the value of CMS_INPUT_LINK

BREAKING CHANGE: The structure of the CaasMapper output for Links in RichTextElements has been
updated