### PR TITLE
fix: NavigationItem typing issue

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -716,7 +716,7 @@ export interface NavigationItem {
   customData: any
   permissions?: {
     allowed: string[]
-    denied: string[]
+    forbidden: string[]
   }
 }
 


### PR DESCRIPTION
There is an issue within the NavigationItem typing which forces using a different parameter in the permissions object than required and provided.