### PR TITLE
Tng 1231 fix remotes

### DIFF
--- a/src/integrations/express.ts
+++ b/src/integrations/express.ts
@@ -172,8 +172,9 @@ function getExpressRouter({ api }: GetExpressRouterContext) {
     )
   }
 
-  router.all('*', (_, res) => {
+  router.all('*', (req, res) => {
     logger.info('trying to resolve all routes')
+    logger.debug('Requested route:', req.route)
     return res.json({
       error: ExpressRouterIntegrationErrors.UNKNOWN_ROUTE,
     })

--- a/src/modules/CaaSMapper.spec.ts
+++ b/src/modules/CaaSMapper.spec.ts
@@ -85,7 +85,7 @@ describe('CaaSMapper', () => {
       expect(mapper._referencedItems).toEqual({ [`${refId}.${locale}`]: [path, path2] })
     })
     it('should register a remote reference and return its remote reference key', () => {
-      const remotes = { remoteId: { id: 'remoteId', locale: 'de' } }
+      const remotes = { someName: { id: 'remoteId', locale: 'de' } }
       const api = createApi()
       api.remotes = remotes
       const mapper = new CaaSMapper(api, 'de', {}, createLogger())
@@ -94,10 +94,10 @@ describe('CaaSMapper', () => {
       const item = mapper.registerReferencedItem(refId, path, 'remoteId')
 
       expect(mapper._remoteReferences).toEqual({
-        remoteId: { [`${refId}.${remotes.remoteId.locale}`]: [path] },
+        remoteId: { [`${refId}.${remotes.someName.locale}`]: [path] },
       })
       expect(mapper._referencedItems).toEqual({})
-      expect(item).toEqual(`[REFERENCED-REMOTE-ITEM-${refId}.${remotes.remoteId.locale}]`)
+      expect(item).toEqual(`[REFERENCED-REMOTE-ITEM-${refId}.${remotes.someName.locale}]`)
     })
     it('should register a non-remote item if the remote project was not found', () => {
       const api = createApi()

--- a/src/modules/CaaSMapper.ts
+++ b/src/modules/CaaSMapper.ts
@@ -47,6 +47,7 @@ import {
   Section,
   CaasApi_Item,
   MappedCaasItem,
+  RemoteProjectConfigurationEntry,
 } from '../types'
 import { parseISO } from 'date-fns'
 import { chunk, update } from 'lodash'
@@ -102,8 +103,8 @@ export class CaaSMapper {
     this.locale = locale
     this.customMapper = utils.customMapper
     this.xmlParser = new XMLParser(logger)
-    Object.keys(this.api.remotes || {}).forEach(
-      (item: string) => (this._remoteReferences[item] = {})
+    Object.values(this.api.remotes || {}).forEach(
+      (entry) => (this._remoteReferences[entry.id] = {})
     )
     this.logger = logger
     this.referenceDepth = utils.referenceDepth ?? 0
@@ -120,6 +121,14 @@ export class CaaSMapper {
   _remoteReferences: {
     [projectId: string]: ReferencedItemsInfo
   } = {}
+
+  private getRemoteConfigForProject(
+    projectId?: string
+  ): RemoteProjectConfigurationEntry | undefined {
+    return projectId
+      ? Object.values(this.api.remotes || {}).find((entry) => entry.id === projectId)
+      : undefined
+  }
 
   addToResolvedReferences(item: MappedCaasItem | CaasApi_Item) {
     // Page has pageId as id instead of PageRef Id. --> use refId instead for mapped Pages
@@ -157,7 +166,7 @@ export class CaaSMapper {
    * @returns placeholder string
    */
   registerReferencedItem(identifier: string, path: NestedPath, remoteProjectId?: string): string {
-    const remoteData = remoteProjectId ? this.api.remotes?.[remoteProjectId] : null
+    const remoteData = this.getRemoteConfigForProject(remoteProjectId)
     const remoteProjectKey = remoteData?.id
     const remoteProjectLocale = remoteData?.locale
 
@@ -751,11 +760,10 @@ export class CaaSMapper {
       ? this._remoteReferences[remoteProjectId]
       : this._referencedItems
 
-    const remoteProjectKey = Object.keys(this.api.remotes || {}).find((key) => {
-      return key === remoteProjectId
-    })
-    const locale =
-      remoteProjectKey && this.api.remotes ? this.api.remotes[remoteProjectKey].locale : this.locale
+    // use remoteProjectLocale if provided. normal locale as standard
+    const remoteProjectData = this.getRemoteConfigForProject(remoteProjectId)
+    const remoteProjectLocale = remoteProjectData?.locale
+    const locale = remoteProjectLocale || this.locale
 
     const referencedIds = Object.keys(referencedItems)
 

--- a/src/modules/FSXARemoteApi.spec.ts
+++ b/src/modules/FSXARemoteApi.spec.ts
@@ -126,7 +126,7 @@ describe('FSXARemoteAPI', () => {
       const config = generateRandomConfig()
       const remoteApi = new FSXARemoteApi(config)
       const remoteProjectId = config.remotes.remote.id
-      const actualCaaSUrl = remoteApi.buildCaaSUrl({ remoteProject: 'remote' })
+      const actualCaaSUrl = remoteApi.buildCaaSUrl({ remoteProject: remoteProjectId })
       const expectedCaaSUrl = `${config.caasURL}/${config.tenantID}/${remoteProjectId}.${config.contentMode}.content`
       expect(actualCaaSUrl).toStrictEqual(expectedCaaSUrl)
     })

--- a/src/modules/FSXARemoteApi.ts
+++ b/src/modules/FSXARemoteApi.ts
@@ -14,9 +14,9 @@ import {
   NavigationItemFilter,
   RemoteApiFilterOptions,
   MappedCaasItem,
-  RemoteProjectConfiguration,
   SortParams,
   CaasApi_Item,
+  RemoteProjectConfiguration,
 } from '../types'
 import { removeFromIdMap, removeFromSeoRouteMap, removeFromStructure } from '../utils'
 import { FSXAApiErrors } from './../enums'
@@ -51,7 +51,7 @@ export class FSXARemoteApi implements FSXAApi {
   private _navigationServiceURL: string = this.navigationServiceURL
   private _tenantID: string = this.tenantID
   private _projectID: string = this.projectID
-  private _remotes: Record<string, { id: string; locale: string }> = this.remotes
+  private _remotes: RemoteProjectConfiguration = this.remotes
   private _contentMode: 'preview' | 'release' = this.contentMode
   private _maxReferenceDepth?: number
   private _customMapper?: CustomMapper
@@ -786,7 +786,7 @@ export class FSXARemoteApi implements FSXAApi {
   /**
    * @returns the configured remote project configuration
    */
-  public get remotes(): Record<string, { id: string; locale: string }> {
+  public get remotes(): RemoteProjectConfiguration {
     return this._remotes
   }
 
@@ -803,7 +803,7 @@ export class FSXARemoteApi implements FSXAApi {
     }
    ```
    */
-  public set remotes(value: Record<string, { id: string; locale: string }>) {
+  public set remotes(value: RemoteProjectConfiguration) {
     const keys = Object.keys(value)
     keys.forEach((key) => {
       const { id, locale } = value[key]

--- a/src/modules/FSXARemoteApi.ts
+++ b/src/modules/FSXARemoteApi.ts
@@ -107,7 +107,6 @@ export class FSXARemoteApi implements FSXAApi {
     this._caasItemFilter = filterOptions?.caasItemFilter
 
     this._logger.debug('FSXARemoteApi created', {
-      apikey,
       caasURL,
       navigationServiceURL,
       tenantID,

--- a/src/modules/FSXARemoteApi.ts
+++ b/src/modules/FSXARemoteApi.ts
@@ -131,11 +131,13 @@ export class FSXARemoteApi implements FSXAApi {
   }
 
   private getRemoteProject(remoteProject: string) {
-    const projectId = this.remotes[remoteProject]?.id
-    if (!projectId) {
+    const remoteProjectConfig = Object.values(this._remotes)
+    const foundRemoteProject = remoteProjectConfig.find((config) => config.id === remoteProject)
+    if (!foundRemoteProject) {
       throw new Error(FSXAApiErrors.UNKNOWN_REMOTE)
     }
-    return projectId
+
+    return remoteProject
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -717,7 +717,7 @@ export interface FSXAConfiguration {
   tenantId: string
   contentMode?: 'preview' | 'release'
   customMapper?: CustomMapper
-  remotes?: Record<string, { id: string; locale: string }>
+  remotes?: RemoteProjectConfiguration
   enableEventStream?: boolean
 }
 
@@ -884,7 +884,15 @@ export interface AppContext<T = unknown> {
   fsxaApi?: FSXAApi
 }
 
-export type RemoteProjectConfiguration = Record<string, { id: string; locale: string }>
+export type RemoteProjectConfiguration = {
+  [name: string]: {
+    id: string
+    locale: string
+  }
+}
+
+export type RemoteProjectConfigurationEntry =
+  RemoteProjectConfiguration[keyof RemoteProjectConfiguration]
 
 export interface CaasItemFilterParams<FilterContextType> extends MapResponse {
   filterContext?: FilterContextType


### PR DESCRIPTION
Fix hidden breaking change:
Remote Config only worked if the remoteName was matching the id

```
{
  'remoteName': {
    id: 'xxxx'
    locale: 'de_DE'
  }
}
```