### PR TITLE
Wrong file names on adjusted exports from package.json

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -76,7 +76,7 @@ await esbuild.build({
   format: 'esm',
   plugins: [
     AnalyzerPlugin({
-        outfile: 'stats/fsxa-api-esm.html',
+        outfile: 'stats/fsxa-api-es5.html',
     })
   ],
 })
@@ -105,7 +105,7 @@ await esbuild.build({
   format: 'esm',
   plugins: [
     AnalyzerPlugin({
-      outfile: 'stats/fsxa-proxy-api-esm.html',
+      outfile: 'stats/fsxa-proxy-api-es5.html',
     })
   ],
 })
@@ -135,7 +135,7 @@ console.log('─'.repeat(60))
 
 console.log('\n✓ Bundle analysis reports generated:')
 console.log('  - stats/fsxa-api-cjs.html')
-console.log('  - stats/fsxa-api-esm.html')
+console.log('  - stats/fsxa-api-es5.html')
 console.log('  - stats/fsxa-proxy-api-cjs.html')
-console.log('  - stats/fsxa-proxy-api-esm.html')
+console.log('  - stats/fsxa-proxy-api-es5.html')
 console.log('\nBuild complete!')

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/fsxa-api.esm.js",
+      "import": "./dist/fsxa-api.es5.js",
       "require": "./dist/fsxa-api.cjs.js",
       "default": "./dist/fsxa-api.cjs.js"
     }

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -13,7 +13,7 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/fsxa-proxy-api.csm.js",
+      "import": "./dist/fsxa-proxy-api.es5.js",
       "require": "./dist/fsxa-proxy-api.cjs.js",
       "default": "./dist/fsxa-proxy-api.cjs.js"
     }


### PR DESCRIPTION
Fixes https://github.com/e-Spirit/javascript-content-api-library/issues/247

Also corrects filenames regarding stats files and build logs

Validation & Integration tests are failing, as this branch is from an external repository. 
Move PR to branch in your repo for correct CI/CD